### PR TITLE
Added *ob-init* and *ob-max* config vars

### DIFF
--- a/src/slacker/common.clj
+++ b/src/slacker/common.clj
@@ -12,3 +12,12 @@
   ^{:doc "Protocol version."}
   version (short 5))
 
+(def
+  ^{:doc "Initial Kryo ObjectBuffer size (bytes)."
+    :dynamic true}
+  *ob-init* (* 1024 1))
+
+(def
+  ^{:doc "Maximum Kryo ObjectBuffer size (bytes)."
+    :dynamic true}
+  *ob-max* (* 1024 16))

--- a/src/slacker/serialization.clj
+++ b/src/slacker/serialization.clj
@@ -36,9 +36,8 @@
   ([_ data] (serialize :carb data :buffer))
   ([_ data ot]
      (if (= ot :bytes)
-       (carb/write-buffer @carb-registry data)
+       (carb/write-buffer @carb-registry data *ob-init* *ob-max*)
        (ByteBuffer/wrap (serialize :carb data :bytes)))))
-
 
 (defmethod deserialize :json
   ([_ data] (deserialize :json data :buffer))
@@ -103,7 +102,7 @@
   ([dct data ot]
      (let [ct (keyword (subs (name dct) 8))
            in-bytes (case ot
-                      :buffer (bytebuffer-bytes data) 
+                      :buffer (bytebuffer-bytes data)
                       :bytes data)
            inflater (InflaterInputStream.
                      (ByteArrayInputStream. in-bytes))


### PR DESCRIPTION
This is dependent on https://github.com/sunng87/carbonite/pull/1.

The default values for _ob-init_ and _ob-max_ are 1 and 16kb, respectively, which matches Kryo's defaults.

I'm not convinced this is necessarily the best way to adjust Kryo's buffer sizes, but binding vars around the slackerc and start-slacker-server calls seemed idiomatic to the rest of the library.

Note that this pull request and https://github.com/sunng87/slacker/pull/4 touch the same code.
