### PR TITLE
core.async for slacker server

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,8 @@
                  [cheshire "5.3.1"]
                  [slingshot "0.10.3"]
                  [org.clojure/java.jmx "0.2.0"]
-                 [org.clojure/tools.logging "0.2.6"]]
+                 [org.clojure/tools.logging "0.2.6"]
+                 [org.clojure/core.async "0.1.278.0-76b25b-alpha"]]
   :profiles {:example {:source-paths ["examples"]}
              :1.3 {:dependencies [org.clojure/clojure "1.3.0"]}}
   :plugins [[lein-exec "0.3.1"]

--- a/src/slacker/server.clj
+++ b/src/slacker/server.clj
@@ -125,12 +125,13 @@
                           client-info inspect-handler)))
 
 ;; async section
-(defonce request-channel (async/chan (async/sliding-buffer 300)))
-(defonce response-channel (async/chan (async/sliding-buffer 300)))
+(defonce ^{:const true} buffer-size 300)
+(defonce request-channel (async/chan (async/sliding-buffer buffer-size)))
+(defonce response-channel (async/chan (async/sliding-buffer buffer-size)))
 
 (defn start-ioc-loop! [handle-request*]
   (async/go-loop []
-                 (let [[ch client-info data] (async/<! request-channel)]
+                 (let [[ch data client-info] (async/<! request-channel)]
                    (async/go
                     (let [result (handle-request* data client-info)]
                       (async/>! response-channel [ch result]))))


### PR DESCRIPTION
Added IoC threads for slacker.server, replaced static executor provided by link.

According to test result, async solution is slightly slower than static thread pool (11%) when hosting CPU bounded functions.

More tests coming soon.