### PR TITLE
Dedicated thread pool for configured namespace

### DIFF
--- a/examples/slacker/example/client.clj
+++ b/examples/slacker/example/client.clj
@@ -20,7 +20,8 @@
 (defn-remote conn slacker.example.api/rand-ints)
 (defn-remote conn slacker.example.api/make-error)
 (defn-remote conn slacker.example.api/return-nil)
-#(defn-remote conn slacker.example.api/not-found)
+#_(defn-remote conn slacker.example.api/not-found)
+(defn-remote conn2 slacker.example.api2/echo2)
 
 (def extension-id 16)
 
@@ -38,6 +39,7 @@
   ;; call a function with another client
   (println (with-slackerc conn2 (timestamp)))
 
+  (println (echo2 "Echo me."))
   (try
     (make-error)
     (catch Exception e

--- a/examples/slacker/example/server.clj
+++ b/examples/slacker/example/server.clj
@@ -1,10 +1,12 @@
 (ns slacker.example.server
-  (:use [slacker server interceptor])
-  (:use slacker.interceptors.stats)
-  (:use slacker.interceptors.exectime)
-  (:use slacker.interceptors.logargs)
   (:require [slacker.example.api]
-            [slacker.serialization.nippy]))
+            [slacker.serialization.nippy]
+            [slacker.server :refer :all]
+            [slacker.interceptor :refer :all]
+            [slacker.interceptors.stats :refer :all]
+            [slacker.interceptors.exectime :refer :all]
+            [slacker.interceptors.logargs :refer :all])
+  (:import [java.util.concurrent Executors]))
 
 (definterceptor log-function-calls
   :before (fn [req]
@@ -15,7 +17,9 @@
   (let [server (start-slacker-server [(the-ns 'slacker.example.api)
                                       {"slacker.example.api2" {"echo2" (fn [n] n)}}]
                                      2104
-                                     :http 4104)]
+                                     :http 4104
+                                     :executors {"slacker.example.api2"
+                                                 (Executors/newFixedThreadPool 2)})]
     (.addShutdownHook (Runtime/getRuntime)
                       (Thread. ^Runnable
                                (fn []

--- a/src/slacker/protocol.clj
+++ b/src/slacker/protocol.clj
@@ -32,6 +32,7 @@
   (enum (byte) {:success 0
                 :not-found 11
                 :exception 12
+                :thread-pool-full 13
                 :protocol-mismatch 20
                 :invalid-packet 21
                 :acl-reject 22}))

--- a/src/slacker/server.clj
+++ b/src/slacker/server.clj
@@ -313,7 +313,8 @@
   * `ssl-context` the SSLContext object for enabling tls support
   * `executor` custom java.util.concurrent.ExecutorService for tasks execution, note this executor will be shutdown when you stop the slacker server
   * `threads` size of thread pool if no executor provided
-  * `queue-size` size of thread pool task queue if no executor provided"
+  * `queue-size` size of thread pool task queue if no executor provided
+  * `executors` a map of dedicated executors, key by namespace. You can configure dedicated thread pool for certain namespace."
   [fn-coll port
    & {:keys [http interceptors ssl-context threads queue-size executor executors]
       :or {interceptors interceptor/default-interceptors

--- a/test/slacker/test/server.clj
+++ b/test/slacker/test/server.clj
@@ -32,7 +32,7 @@
 
 (deftest test-server-pipeline-interceptors
   (let [server-pipeline (build-server-pipeline
-                         funcs {:pre identity :before identity :after interceptor :post identity}
+                         {:pre identity :before identity :after interceptor :post identity}
                          (atom {}))
         req {:content-type :nippy
              :data (serialize :nippy [100 0])


### PR DESCRIPTION
Fixes #58 

You can configure dedicated executor for given namespace of functions via `:executors` map.