### PR TITLE
Exchange client information upon connection

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "http://github.com/sunng87/slacker"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[link "0.11.2-SNAPSHOT"]
+  :dependencies [[link "0.11.1"]
                  [rigui "0.5.2"]
                  [manifold "0.1.6"]
                  [org.clojure/tools.logging "0.4.0"]

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "http://github.com/sunng87/slacker"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[link "0.11.2-SNAPSHOT"]
+  :dependencies [[link "0.11.2"]
                  [rigui "0.5.2"]
                  [manifold "0.1.6"]
                  [org.clojure/tools.logging "0.4.0"]

--- a/project.clj
+++ b/project.clj
@@ -3,10 +3,11 @@
   :url "http://github.com/sunng87/slacker"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[link "0.11.1"]
+  :dependencies [[link "0.11.2-SNAPSHOT"]
                  [rigui "0.5.2"]
                  [manifold "0.1.6"]
-                 [org.clojure/tools.logging "0.4.0"]]
+                 [org.clojure/tools.logging "0.4.0"]
+                 [trptcolin/versioneer "0.2.0"]]
   :profiles {:example {:source-paths ["examples"]
                        :dependencies [[org.clojure/java.jmx "0.3.4"]]}
              :dev {:dependencies [[org.clojure/clojure "1.9.0"]

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "http://github.com/sunng87/slacker"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[link "0.11.1"]
+  :dependencies [[link "0.11.2-SNAPSHOT"]
                  [rigui "0.5.2"]
                  [manifold "0.1.6"]
                  [org.clojure/tools.logging "0.4.0"]

--- a/src/slacker/client.clj
+++ b/src/slacker/client.clj
@@ -123,3 +123,8 @@
       (merge metadata
              (meta-remote sc (str remote-ns "/" remote-fn)))
       metadata)))
+
+(defn slacker-server-status
+  "Fetch server status of current slacker server."
+  [sc]
+  (clients-remote sc))

--- a/src/slacker/client/common.clj
+++ b/src/slacker/client/common.clj
@@ -478,5 +478,14 @@
       (throw (ex-info "Slacker client error"
                       (user-friendly-cause call-result))))))
 
+(defn clients-remote
+  "get clients information on remote server"
+  [sc]
+  (let [call-result (inspect @sc :clients nil)]
+    (if (nil? (:cause call-result))
+      (:result call-result)
+      (throw (ex-info "Slacker client error"
+                      (user-friendly-cause call-result))))))
+
 (defn shutdown-factory [factory]
   (shutdown factory))

--- a/src/slacker/client/common.clj
+++ b/src/slacker/client/common.clj
@@ -28,7 +28,7 @@
       {:cause {:error :invalid-result-code}})))
 
 (defn make-client-hello [client-version client-name]
-  [client-version client-name])
+  [0 [:type-client-hello [client-version client-name]]])
 
 (defn make-request [tid content-type func-name params extensions]
   [tid [:type-request [content-type func-name params extensions]]])
@@ -360,6 +360,9 @@
                     slacker-client (->> addr-str
                                         (get-purgatory @factory-ref)
                                         :refs
+                                        ;; TODO: multiple client to
+                                        ;; same server with different
+                                        ;; configuration
                                         (filter #(= addr-str (.-addr %)))
                                         first)
                     slacker-options (.-options slacker-client)

--- a/src/slacker/client/common.clj
+++ b/src/slacker/client/common.clj
@@ -360,7 +360,7 @@
                     slacker-client (->> addr-str
                                         (get-purgatory @factory-ref)
                                         :refs
-                                        ;; TODO: multiple client to
+                                        ;; TODO: multiple clients to
                                         ;; same server with different
                                         ;; configuration
                                         (filter #(= addr-str (.-addr %)))

--- a/src/slacker/client/common.clj
+++ b/src/slacker/client/common.clj
@@ -364,14 +364,15 @@
                                         ;; same server with different
                                         ;; configuration
                                         (filter #(= addr-str (.-addr %)))
-                                        first)
-                    slacker-options (.-options slacker-client)
-                    protocol-version (:protocol-version slacker-options)
-                    client-name (:client-name slacker-options "")]
-                (log/debug "slacker-options for this channel:" slacker-options)
-                (send! ch
-                       (protocol/of protocol-version
-                                    (make-client-hello client-version client-name)))))
+                                        first)]
+                (when slacker-client
+                  (let [slacker-options (.-options slacker-client)
+                        protocol-version (:protocol-version slacker-options)
+                        client-name (:client-name slacker-options "")]
+                    (log/debug "slacker-options for this channel:" slacker-options)
+                    (send! ch
+                           (protocol/of protocol-version
+                                        (make-client-hello client-version client-name)))))))
    (on-inactive [ch]
                 (when-let [rmap (->> ch
                                      (channel-hostport)

--- a/src/slacker/common.clj
+++ b/src/slacker/common.clj
@@ -1,4 +1,5 @@
-(ns slacker.common)
+(ns slacker.common
+  (:require [trptcolin.versioneer.core :as ver]))
 
 (def
   ^{:doc "Debug flag. This flag can be override by binding if you like to see some debug output."
@@ -35,3 +36,6 @@
    sent to remote server using same content type with the request body."
   [ext-map & body]
   `(binding [*extensions* ~ext-map] ~@body))
+
+(def slacker-version
+  (ver/get-version "slacker" "slacker"))

--- a/src/slacker/protocol.clj
+++ b/src/slacker/protocol.clj
@@ -5,6 +5,8 @@
 (def ^:const v5 5)
 (def ^:const v6 6)
 
+(def ^:const default-version v6)
+
 (def versions
   (enum (byte) {v5 5
                 v6 6}))
@@ -122,14 +124,14 @@
 (def slacker-client-hello-codec
   (frame
    ;; client version
-   (string :prefix (uint16))
+   (string :encoding :utf-8 :prefix (uint16))
    ;; client name
-   (string :prefix (uint16))))
+   (string :encoding :utf-8 :prefix (uint16))))
 
 (def slacker-server-hello-codec
   (frame
    ;; server version
-   (string :prefix (uint16))
+   (string :encoding :utf-8 :prefix (uint16))
    ))
 
 (def slacker-v5-codec
@@ -175,4 +177,4 @@
 ;; helper function
 
 (defn of [v data]
-  [(or v v6) data])
+  [(or v default-version) data])

--- a/src/slacker/protocol.clj
+++ b/src/slacker/protocol.clj
@@ -19,7 +19,9 @@
                 :type-auth-ack 6
                 :type-inspect-req 7
                 :type-inspect-ack 8
-                :type-interrupt 9}))
+                :type-interrupt 9
+                :type-client-hello 10
+                :type-server-hello 11}))
 
 (def content-type
   (enum (byte) {:carb 0 :json 1 :clj 2 :nippy 3
@@ -117,6 +119,19 @@
   (frame
    (int32)))
 
+(def slacker-client-hello-codec
+  (frame
+   ;; client version
+   (string :prefix (uint16))
+   ;; client name
+   (string :prefix (uint16))))
+
+(def slacker-server-hello-codec
+  (frame
+   ;; server version
+   (string :prefix (uint16))
+   ))
+
 (def slacker-v5-codec
   (frame
    (int32) ;; transaction id
@@ -147,7 +162,9 @@
      :type-auth-ack slacker-auth-ack-codec
      :type-inspect-req slacker-inspect-req-codec
      :type-inspect-ack slacker-inspect-ack-codec
-     :type-interrupt slacker-interrupt-codec})))
+     :type-interrupt slacker-interrupt-codec
+     :type-client-hello slacker-client-hello-codec
+     :type-server-hello slacker-server-hello-codec})))
 
 (def slacker-root-codec
   (header

--- a/src/slacker/protocol.clj
+++ b/src/slacker/protocol.clj
@@ -108,7 +108,8 @@
 (def slacker-inspect-req-codec
   (frame
    (enum (byte) {:functions 0
-                 :meta 1})
+                 :meta 1
+                 :clients 2})
    (byte-block :prefix (uint16))))
 
 ;; type-inspect-ack

--- a/src/slacker/protocol.clj
+++ b/src/slacker/protocol.clj
@@ -179,3 +179,6 @@
 
 (defn of [v data]
   [(or v default-version) data])
+
+(defn packet-type-from-frame [p]
+  (let [[_ [_ [packet-type]]] p] packet-type))

--- a/src/slacker/server.clj
+++ b/src/slacker/server.clj
@@ -195,15 +195,15 @@
       (.release ^ByteBuf bb))))
 
 ;; p: [version [tid [type ...]]]
-(defmulti ^:private -handle-request (fn [p & _] (let [[_ [_ [packet-type]]] p] packet-type)))
-(defmethod -handle-request :type-request [req
-                                          server-pipeline
-                                          client-info
-                                          inspect-handler
-                                          running-threads
-                                          executors
-                                          funcs
-                                          & _]
+(defmulti ^:private -handle-request
+  (fn [_ p _] (protocol/packet-type-from-frame p)))
+
+(defmethod -handle-request :type-request [{:keys [server-pipeline
+                                                  inspect-handler
+                                                  running-threads
+                                                  executors
+                                                  funcs]}
+                                          req client-info]
   (let [req-map (assoc (map-req-fields req) :client client-info)
         req-map (look-up-function req-map funcs)]
     (if (nil? (:code req-map))
@@ -236,13 +236,13 @@
         (error-packet (:version req-map) (:tid req-map) :not-found)
         (finally
           (release-buffer! req-map))))))
-(defmethod -handle-request :type-ping [[version [tid _]] & _]
+(defmethod -handle-request :type-ping [_ [version [tid _]] _]
   (pong-packet version tid))
-(defmethod -handle-request :type-inspect-req [p _ _ inspect-handler & _]
+(defmethod -handle-request :type-inspect-req [{:keys [inspect-handler]} p _]
   (inspect-handler p))
-(defmethod -handle-request :type-interrupt [p _ client-info _ running-threads & _]
+(defmethod -handle-request :type-interrupt [{:keys [running-threads]} p client-info]
   (interrupt-handler p client-info running-threads))
-(defmethod -handle-request :type-client-hello [p _ client-info _ _ _ _ connected-clients]
+(defmethod -handle-request :type-client-hello [{:keys [connected-clients]} p client-info]
   (let [[version [tid [_ [client-version client-name]]]] p
         client-data {:addr (str (:remote-addr client-info))
                      :name client-name
@@ -250,37 +250,34 @@
                      :connected-on (System/currentTimeMillis)}]
     (swap! connected-clients assoc (:remote-addr client-info) client-data)
     (server-hello-packet version tid slacker-version)))
-(defmethod -handle-request :default [[version [tid _]] & _]
+(defmethod -handle-request :default [_ [version [tid _]] _]
   (error-packet version tid :invalid-packet))
 
 
 (defn ^:no-doc handle-request
-  [server-pipeline req client-info inspect-handler running-threads executors
-   funcs connected-clients]
-  (log/debug req)
-  (-handle-request req server-pipeline
-                   client-info inspect-handler running-threads
-                   executors funcs connected-clients))
+  [context request client-info]
+  (log/debug request)
+  (-handle-request context request client-info))
 
-(defn- create-server-handler [executors funcs interceptors
-                              running-threads connected-clients]
-  (let [server-pipeline (build-server-pipeline interceptors running-threads)
-        inspect-handler (build-inspect-handler funcs connected-clients)]
+(defn- create-server-handler [{:keys [executors funcs interceptors]}]
+  (let [running-threads (atom {})
+        connected-clients (atom {})
+
+        server-pipeline (build-server-pipeline interceptors running-threads)
+        inspect-handler (build-inspect-handler funcs connected-clients)
+        handle-request-partial (partial handle-request
+                                        {:server-pipeline server-pipeline
+                                         :inspect-handler inspect-handler
+                                         :running-threads running-threads
+                                         :executors executors
+                                         :funcs funcs
+                                         :connected-clients connected-clients})]
     (create-handler
      (on-message [ch data]
                  (log/debug "data received" data)
                  (let [client-info {:remote-addr (remote-addr ch)
                                     :channel ch}
-                       ;; FIXME: refactor arguments
-                       result (handle-request
-                               server-pipeline
-                               data
-                               client-info
-                               inspect-handler
-                               running-threads
-                               executors
-                               funcs
-                               connected-clients)]
+                       result (handle-request-partial data client-info)]
                    (log/debug "result" result)
                    (when-not (or (nil? result) (= :interrupted (:code result)))
                      (send! ch result))))
@@ -326,13 +323,10 @@
         server-pipeline (build-server-pipeline interceptors nil)]
     (fn [req]
       (let [client-info (http-client-info req)
-            curried-handler (fn [req] (handle-request server-pipeline
+            curried-handler (fn [req] (handle-request {:server-pipeline server-pipeline
+                                                      :funcs funcs}
                                                      req
-                                                     client-info
-                                                     nil
-                                                     nil
-                                                     nil
-                                                     nil))]
+                                                     client-info))]
         (-> req
             ring-req->slacker-req
             curried-handler
@@ -354,7 +348,7 @@
   Options:
 
   * `interceptors` add server interceptors
-  * `http` http port for slacker http transport
+  * `Http` Http port for slacker http transport
   * `ssl-context` the SSLContext object for enabling tls support
   * `executor` custom java.util.concurrent.ExecutorService for tasks execution, note this executor will be shutdown when you stop the slacker server
   * `threads` size of thread pool if no executor provided
@@ -372,10 +366,9 @@
         funcs (apply merge (map parse-funcs fn-coll))
         default-executor (or executor (thread-pool-executor threads queue-size))
         executors (assoc executors :default default-executor)
-        running-threads (atom {})
-        connected-clients (atom {})
-        handler (create-server-handler executors funcs interceptors
-                                       running-threads connected-clients)
+        handler (create-server-handler {:executors executors
+                                        :funcs funcs
+                                        :interceptors interceptors})
         ssl-handler (when ssl-context
                       (ssl-handler-from-jdk-ssl-context ssl-context false))
         handlers [(netty-encoder protocol/slacker-root-codec)

--- a/src/slacker/server.clj
+++ b/src/slacker/server.clj
@@ -10,7 +10,8 @@
             [slacker.interceptor :as interceptor]
             [link.ssl :refer [ssl-handler-from-jdk-ssl-context]]
             [link.codec :refer [netty-encoder netty-decoder]])
-  (:import [java.util.concurrent TimeUnit ExecutorService
+  (:import [java.util Date]
+           [java.util.concurrent TimeUnit ExecutorService
             ThreadPoolExecutor LinkedBlockingQueue RejectedExecutionHandler
             RejectedExecutionException ThreadPoolExecutor$AbortPolicy ThreadFactory]
            [io.netty.buffer ByteBuf]))
@@ -247,7 +248,7 @@
         client-data {:addr (str (:remote-addr client-info))
                      :name client-name
                      :version client-version
-                     :connected-on (System/currentTimeMillis)}]
+                     :connected-on (Date.)}]
     (swap! connected-clients assoc (:remote-addr client-info) client-data)
     (server-hello-packet version tid slacker-version)))
 (defmethod -handle-request :default [_ [version [tid _]] _]

--- a/src/slacker/server.clj
+++ b/src/slacker/server.clj
@@ -238,8 +238,8 @@
           (release-buffer! req-map))))))
 (defmethod -handle-request :type-ping [[version [tid _]] & _]
   (pong-packet version tid))
-(defmethod -handle-request :type-inspect-req [p _ _ inspect-handler _ _ _ connected-clients & _]
-  (inspect-handler p connected-clients))
+(defmethod -handle-request :type-inspect-req [p _ _ inspect-handler & _]
+  (inspect-handler p))
 (defmethod -handle-request :type-interrupt [p _ client-info _ running-threads & _]
   (interrupt-handler p client-info running-threads))
 (defmethod -handle-request :type-client-hello [p _ client-info _ _ _ _ connected-clients]
@@ -265,7 +265,7 @@
 (defn- create-server-handler [executors funcs interceptors
                               running-threads connected-clients]
   (let [server-pipeline (build-server-pipeline interceptors running-threads)
-        inspect-handler (build-inspect-handler funcs)]
+        inspect-handler (build-inspect-handler funcs connected-clients)]
     (create-handler
      (on-message [ch data]
                  (log/debug "data received" data)

--- a/src/slacker/server.clj
+++ b/src/slacker/server.clj
@@ -169,7 +169,7 @@
                               metadata (meta (funcs fname))]
                           (select-keys metadata [:name :doc :arglists]))
                         :clients
-                        @connected-clients
+                        (vals @connected-clients)
                         nil)
               sresult (serialize :clj results)]
           (make-inspect-ack prot-ver tid sresult))

--- a/test/slacker/test/server.clj
+++ b/test/slacker/test/server.clj
@@ -42,12 +42,12 @@
 
 (deftest test-ping
   (let [request [protocol/v5 [0 [:type-ping]]]
-        [_ [_ response]] (handle-request nil request nil nil nil nil nil nil)]
+        [_ [_ response]] (handle-request {} request nil)]
     (is (= :type-pong (nth response 0)))))
 
 (deftest test-invalid-packet
   (let [request [protocol/v5 [0 [:type-unknown]]]
-        [_ [_ response]] (handle-request nil request nil nil nil nil nil nil)]
+        [_ [_ response]] (handle-request {} request nil)]
     (is (= :type-error (nth response 0)))
     (is (= :invalid-packet (-> response
                                second
@@ -57,9 +57,8 @@
 (deftest test-functions-inspect
   (let [request [protocol/v5 [0 [:type-inspect-req [:functions
                                                     (Unpooled/wrappedBuffer (.getBytes "\"a\""))]]]]
-        [_ [_ [_ [result]]]] (handle-request nil request nil
-                                             (build-inspect-handler funcs (atom {}))
-                                             nil nil nil nil)
+        [_ [_ [_ [result]]]] (handle-request {:inspect-handler (build-inspect-handler funcs (atom {}))}
+                                             request nil)
         response (deserialize :clj result)]
     (is (= (keys funcs) response))))
 

--- a/test/slacker/test/server.clj
+++ b/test/slacker/test/server.clj
@@ -42,12 +42,12 @@
 
 (deftest test-ping
   (let [request [protocol/v5 [0 [:type-ping]]]
-        [_ [_ response]] (handle-request nil request nil nil nil nil nil)]
+        [_ [_ response]] (handle-request nil request nil nil nil nil nil nil)]
     (is (= :type-pong (nth response 0)))))
 
 (deftest test-invalid-packet
   (let [request [protocol/v5 [0 [:type-unknown]]]
-        [_ [_ response]] (handle-request nil request nil nil nil nil nil)]
+        [_ [_ response]] (handle-request nil request nil nil nil nil nil nil)]
     (is (= :type-error (nth response 0)))
     (is (= :invalid-packet (-> response
                                second
@@ -58,8 +58,8 @@
   (let [request [protocol/v5 [0 [:type-inspect-req [:functions
                                                     (Unpooled/wrappedBuffer (.getBytes "\"a\""))]]]]
         [_ [_ [_ [result]]]] (handle-request nil request nil
-                                             (build-inspect-handler funcs)
-                                             nil nil nil)
+                                             (build-inspect-handler funcs (atom {}))
+                                             nil nil nil nil)
         response (deserialize :clj result)]
     (is (= (keys funcs) response))))
 


### PR DESCRIPTION
Send some client information to server when connected, which could make it possible for server to control the behaviour for different client.

This is a re-implementation of #62

