### PR TITLE
Server side async function

### DIFF
--- a/examples/slacker/example/api.clj
+++ b/examples/slacker/example/api.clj
@@ -1,5 +1,6 @@
 (ns slacker.example.api
   (:require [slacker.common :as s]
+            [manifold.deferred :as d]
             [clojure.tools.logging :as logging]))
 
 (defn timestamp []
@@ -41,3 +42,11 @@
 
 (defn -slacker-function-not-found [fname args]
   ["Function not found: " fname args])
+
+(defn async-result []
+  (let [defr (d/deferred)]
+    (doto (Thread. #(do
+                      (Thread/sleep 300)
+                      (d/success! defr "Deferred result.")))
+      (.start))
+    defr))

--- a/examples/slacker/example/api.clj
+++ b/examples/slacker/example/api.clj
@@ -50,3 +50,10 @@
                       (d/success! defr "Deferred result.")))
       (.start))
     defr))
+
+(defn async-exception []
+  (let [defr (d/deferred)]
+    (doto (Thread. #(do
+                      (d/error! defr (RuntimeException. "Expected error in async fn."))))
+      (.start))
+    defr))

--- a/examples/slacker/example/client.clj
+++ b/examples/slacker/example/client.clj
@@ -21,6 +21,7 @@
 (defn-remote conn slacker.example.api/make-error)
 (defn-remote conn slacker.example.api/return-nil)
 (defn-remote conn slacker.example.api/async-result)
+(defn-remote conn slacker.example.api/async-exception)
 #_(defn-remote conn slacker.example.api/not-found)
 (defn-remote conn2 slacker.example.api2/echo2)
 
@@ -51,6 +52,12 @@
 
   (println "Calling server-side async function: "
            (async-result))
+
+  (println "Calling a server-side async function that throws exception: ")
+  (try
+    (async-exception)
+    (catch Exception e
+      (println "Exception received: " (-> (ex-data e) :cause :exception))))
 
   (println (echo2 "Echo me."))
   (try

--- a/examples/slacker/example/client.clj
+++ b/examples/slacker/example/client.clj
@@ -20,6 +20,7 @@
 (defn-remote conn slacker.example.api/rand-ints)
 (defn-remote conn slacker.example.api/make-error)
 (defn-remote conn slacker.example.api/return-nil)
+(defn-remote conn slacker.example.api/async-result)
 #_(defn-remote conn slacker.example.api/not-found)
 (defn-remote conn2 slacker.example.api2/echo2)
 
@@ -47,6 +48,9 @@
   ;; call a non-exist function, catched by -slacker-function-not-found
   (println "Calling non-exist function: "
            (call-remote conn "slacker.example.api" "no-such-fn" [1 2 3]))
+
+  (println "Calling server-side async function: "
+           (async-result))
 
   (println (echo2 "Echo me."))
   (try

--- a/src/slacker/server.clj
+++ b/src/slacker/server.clj
@@ -368,7 +368,6 @@
                               (handle-request {:server-pipeline server-pipeline
                                                :funcs funcs
                                                :send-response (fn [_ resp]
-                                                                ;; TODO: full async
                                                                 (-> resp
                                                                     map-response-fields
                                                                     slacker-resp->ring-resp

--- a/src/slacker/server.clj
+++ b/src/slacker/server.clj
@@ -9,7 +9,8 @@
             [slacker.server.http :refer :all]
             [slacker.interceptor :as interceptor]
             [link.ssl :refer [ssl-handler-from-jdk-ssl-context]]
-            [link.codec :refer [netty-encoder netty-decoder]])
+            [link.codec :refer [netty-encoder netty-decoder]]
+            [manifold.deferred :as d])
   (:import [java.util Date]
            [java.util.concurrent TimeUnit ExecutorService
             ThreadPoolExecutor LinkedBlockingQueue RejectedExecutionHandler
@@ -34,11 +35,13 @@
                        ^RejectedExecutionHandler (ThreadPoolExecutor$AbortPolicy.)))
 
 (defmacro ^:private with-executor [executor & body]
-  `(.submit ~executor
-            ^Runnable (cast Runnable
-                            (fn [] (try ~@body
-                                       (catch Throwable e#
-                                         (log/warn e# "Uncaught exception in Slacker executor")))))))
+  `(if ~executor
+     (.submit ~executor
+              ^Runnable (cast Runnable
+                              (fn [] (try ~@body
+                                         (catch Throwable e#
+                                           (log/warn e# "Uncaught exception in Slacker executor"))))))
+     (do ~@body)))
 
 (defn- thread-map-key [client tid]
   (str (:remote-addr client) "::" tid))
@@ -74,6 +77,16 @@
                                         extensions))))
     req))
 
+(defn- future-result? [r]
+  (d/deferred? r))
+
+(defn- invoke-error-handler [req e]
+  (if-not *debug*
+    (assoc req :code :exception :result (str e) :exception e)
+    (assoc req :code :exception
+           :result {:msg (.getMessage ^Exception e)
+                    :stacktrace (.getStackTrace ^Exception e)})))
+
 (defn- do-invoke [req]
   (if (nil? (:code req))
     (try
@@ -84,20 +97,24 @@
                    (apply f args)
                    (f fn-name args))
               r (if (seq? r0) (doall r0) r0)]
-          (assoc req :result r :code :success)))
+          (if-not (future-result? r)
+            ;; sync call
+            (assoc req :result r :code :success)
+            ;; async call
+            (assoc req :future
+                   (-> r
+                       (d/chain #(assoc req :result % :code :success))
+                       (d/catch #(invoke-error-handler req %)))))))
       (catch InterruptedException e
         (log/info "Thread execution interrupted." (:client req) (:tid req))
         (assoc req :code :interrupted))
       (catch Throwable e
-        (if-not *debug*
-          (assoc req :code :exception :result (str e) :exception e)
-          (assoc req :code :exception
-                 :result {:msg (.getMessage ^Exception e)
-                          :stacktrace (.getStackTrace ^Exception e)}))))
+        (invoke-error-handler req e)))
     req))
 
 (defn- call-interceptor [req interceptor]
   (try
+    ;; TODO: async
     (interceptor req)
     (catch Throwable e
       (if-not *debug*
@@ -106,12 +123,17 @@
                :result {:msg (.getMessage ^Exception e)
                         :stacktrace (.getStackTrace ^Exception e)})))))
 
-(defn- serialize-result [req]
+(defn- do-serialize-result [req]
   (assoc req
          :result (serialize (:content-type req) (:result req))
          :raw-extensions (->> (:extensions req)
-                          (into [])
-                          (mapv #(update % 1 (partial serialize (:content-type req)))))))
+                              (into [])
+                              (mapv #(update % 1 (partial serialize (:content-type req)))))))
+
+(defn- serialize-result [req]
+  (if-let [future-result (:future req)]
+    (assoc req :future (d/chain future-result do-serialize-result))
+    (do-serialize-result req)))
 
 (defn- map-response-fields [req]
   (protocol/of (:protocol-version req)
@@ -208,6 +230,11 @@
 (defmulti ^:private -handle-request
   (fn [_ p _] (protocol/packet-type-from-frame p)))
 
+(defn- write-response [client-info resp]
+  (let [result (map-response-fields resp)]
+    (when-not (or (nil? result) (= :interrupted (:code result)))
+      (link/send! (:channel client-info) result))))
+
 (defmethod -handle-request :type-request [{:keys [server-pipeline
                                                   inspect-handler
                                                   running-threads
@@ -217,41 +244,42 @@
   (let [req-map (assoc (map-req-fields req) :client client-info)
         req-map (look-up-function req-map funcs)]
     (if (nil? (:code req-map))
-      (if-let [thread-pool (get executors (:ns-name req-map)
-                                          (:default executors))]
-        ;; async run on dedicated or global thread pool
-        ;; http call always runs on default thread
-        (do
-          (try
-            (with-executor ^ThreadPoolExecutor thread-pool
-              (try
-                (let [result (map-response-fields (server-pipeline req-map))]
-                  (when-not (or (nil? result) (= :interrupted (:code result)))
-                    (link/send! (:channel client-info) result)))
-                (finally
-                  (release-buffer! req-map))))
-            ;; async run, return nil so sync wait won't send
-            nil
-            (catch RejectedExecutionException _
-              (log/warn "Server thread pool is full for" (:ns-name req-map))
-              (release-buffer! req-map)
-              (error-packet (:version req-map) (:tid req-map) :thread-pool-full))))
-        ;; run on default thread
+      (let [thread-pool (get executors (:ns-name req-map)
+                             (:default executors))]
         (try
-          (map-response-fields (server-pipeline req-map))
-          (finally
-            (release-buffer! req-map))))
+          (with-executor ^ThreadPoolExecutor thread-pool
+            ;; when thread-pool is nil the body will run on default
+            ;; thread. We keep it return null so we will deal with the
+            ;; result sending.
+            ;; async run on dedicated or global thread pool
+            ;; http call always runs on default thread
+            (try
+              (let [resp (server-pipeline req-map)]
+                (if-let [resp-future (:future resp)]
+                  (d/chain resp-future (partial write-response client-info))
+                  (write-response client-info resp)))
+              (finally
+                (release-buffer! req-map)))
+            nil)
+          ;; async run, return nil so sync wait won't send
+          nil
+          (catch RejectedExecutionException _
+            (log/warn "Server thread pool is full for" (:ns-name req-map))
+            (release-buffer! req-map)
+            (error-packet (:version req-map) (:tid req-map) :thread-pool-full))))
       ;; return error
       (try
         (error-packet (:version req-map) (:tid req-map) :not-found)
         (finally
           (release-buffer! req-map))))))
-(defmethod -handle-request :type-ping [_ [version [tid _]] _]
-  (pong-packet version tid))
-(defmethod -handle-request :type-inspect-req [{:keys [inspect-handler]} p _]
-  (inspect-handler p))
+
+(defmethod -handle-request :type-ping [_ [version [tid _]] {ch :channel}]
+  (link/send! ch (pong-packet version tid)))
+(defmethod -handle-request :type-inspect-req [{:keys [inspect-handler]} p {ch :channel}]
+  (link/send! ch (inspect-handler p)))
 (defmethod -handle-request :type-interrupt [{:keys [running-threads]} p client-info]
-  (interrupt-handler p client-info running-threads))
+  (link/send! (:channel client-info)
+              (interrupt-handler p client-info running-threads)))
 (defmethod -handle-request :type-client-hello [{:keys [server-status]} p client-info]
   (let [[version [tid [_ [client-version client-name]]]] p
         client-data {:addr (str (:remote-addr client-info))
@@ -260,9 +288,10 @@
                      :connected-on (Date.)}]
     (swap! server-status update-in [:connected-clients]
            assoc (:remote-addr client-info) client-data)
-    (server-hello-packet version tid slacker-version)))
-(defmethod -handle-request :default [_ [version [tid _]] _]
-  (error-packet version tid :invalid-packet))
+    (link/send! (:channel client-info)
+                (server-hello-packet version tid slacker-version))))
+(defmethod -handle-request :default [_ [version [tid _]] {ch :channel}]
+  (link/send! ch (error-packet version tid :invalid-packet)))
 
 
 (defn ^:no-doc handle-request
@@ -289,11 +318,8 @@
      (on-message [ch data]
                  (log/debug "data received" data)
                  (let [client-info {:remote-addr (remote-addr ch)
-                                    :channel ch}
-                       result (handle-request-partial data client-info)]
-                   (log/debug "result" result)
-                   (when-not (or (nil? result) (= :interrupted (:code result)))
-                     (send! ch result))))
+                                    :channel ch}]
+                   (handle-request-partial data client-info)))
      (on-error [ch ^Exception e]
                (log/error e "Unexpected error in event loop")
                (close! ch))

--- a/src/slacker/server.clj
+++ b/src/slacker/server.clj
@@ -245,7 +245,8 @@
                                                   running-threads
                                                   executors
                                                   funcs
-                                                  send-response]}
+                                                  send-response]
+                                           :or {send-response link-write-response}}
                                           req client-info]
   (let [req-map (assoc (map-req-fields req) :client client-info)
         req-map (look-up-function req-map funcs)]

--- a/src/slacker/server/http.clj
+++ b/src/slacker/server/http.clj
@@ -33,8 +33,7 @@
 (defn slacker-resp->ring-resp
   "transform slacker response to ring response"
   [resp]
-  (let [resp (if (:future resp) @(:future resp) resp)
-        [_ [_ resp-body]] resp
+  (let [[_ [_ resp-body]] resp
         packet-type (first resp-body)]
     (let [[ct code result _] (second resp-body)
           content-type (str "application/" (name ct))
@@ -47,8 +46,6 @@
       {:status status
        :headers {"content-type" content-type}
        :body body})))
-
-
 
 (defn http-client-info
   "Get http client information (remote IP) from ring request"

--- a/src/slacker/server/http.clj
+++ b/src/slacker/server/http.clj
@@ -33,7 +33,8 @@
 (defn slacker-resp->ring-resp
   "transform slacker response to ring response"
   [resp]
-  (let [[_ [_ resp-body]] resp
+  (let [resp (if (:future resp) @(:future resp) resp)
+        [_ [_ resp-body]] resp
         packet-type (first resp-body)]
     (let [[ct code result _] (second resp-body)
           content-type (str "application/" (name ct))


### PR DESCRIPTION
This patch provides server-side async function support to slacker framework.

By returning a manifold `deferred`, you function is treated as an async one. The result will be delivered to client eventually as well as traditional sync function. Additional features like interceptor, http are also supported.
