### PR TITLE
Implement fire and forget RPC call

### DIFF
--- a/examples/slacker/example/client.clj
+++ b/examples/slacker/example/client.clj
@@ -7,7 +7,7 @@
 (def conn (slackerc "127.0.0.1:2104" :ping-interval 5 :content-type :nippy))
 (def conn2 (slackerc "127.0.0.1:2104" :content-type :transit-json
                      :protocol-version v5))
-(defn-remote conn slacker.example.api/timestamp)
+(defn-remote conn slacker.example.api/timestamp :fire-and-forget? true)
 (defn-remote conn2 slacker.example.api/inc-m)
 (defn-remote conn slacker.example.api/get-m :async? true)
 (defn-remote conn2 show-m

--- a/project.clj
+++ b/project.clj
@@ -17,8 +17,7 @@
                                   [com.cognitect/transit-clj "1.0.324"]
                                   [log4j "1.2.17"]]}
              :clojure18 {:dependencies [[org.clojure/clojure "1.8.0"]]}
-             :clojure19 {:dependencies [[org.clojure/clojure "1.9.0"]]}
-             :clojure110 {:dependencies [[org.clojure/clojure "1.10.1"]]}}
+             :clojure19 {:dependencies [[org.clojure/clojure "1.9.0"]]}}
   :plugins [[lein-exec "0.3.1"]
             [lein-codox "0.10.7"]]
   :global-vars {*warn-on-reflection* true}

--- a/src/slacker/client.clj
+++ b/src/slacker/client.clj
@@ -46,10 +46,13 @@
 (defmacro defn-remote
   "Define a facade for remote function. You have to provide the
   connection and the function name. (Argument list is not required here.)"
-  ([sc fname & {:keys [remote-ns remote-name async? callback extensions]
+  ([sc fname & {:keys [remote-ns remote-name async? fire-and-forget?
+                       callback extensions]
                 :or {remote-ns (ns-name *ns*)
                      remote-name nil
-                     async? false callback nil}
+                     async? false
+                     fire-and-forget? false
+                     callback nil}
                 :as options}]
      (let [fname-str (str fname)
            remote-ns-declared (> (.indexOf fname-str "/") 0)


### PR DESCRIPTION
Fixes #73 

This patch adds a new option `fire-and-forget?` to `defn-remote`. The new option allows remote call returns immediately and creates no callback/promise. 